### PR TITLE
Fixed OMS codes ordering

### DIFF
--- a/src/V2/Dto/CreateOrderForEmissionICResponse.php
+++ b/src/V2/Dto/CreateOrderForEmissionICResponse.php
@@ -17,13 +17,13 @@ final class CreateOrderForEmissionICResponse
     /**
      * @var int
      */
-    private $expectedCompletionTime;
+    private $expectedCompleteTimestamp;
 
-    public function __construct(string $omsId, string $orderId, int $expectedCompletionTime)
+    public function __construct(string $omsId, string $orderId, int $expectedCompleteTimestamp)
     {
         $this->omsId = $omsId;
         $this->orderId = $orderId;
-        $this->expectedCompletionTime = $expectedCompletionTime;
+        $this->expectedCompleteTimestamp = $expectedCompleteTimestamp;
     }
 
     public function getOmsId(): string
@@ -36,8 +36,8 @@ final class CreateOrderForEmissionICResponse
         return $this->orderId;
     }
 
-    public function getExpectedCompletionTime(): int
+    public function getExpectedCompleteTimestamp(): int
     {
-        return $this->expectedCompletionTime;
+        return $this->expectedCompleteTimestamp;
     }
 }

--- a/src/V2/Dto/GetICBufferStatusResponse.php
+++ b/src/V2/Dto/GetICBufferStatusResponse.php
@@ -6,11 +6,11 @@ namespace Lamoda\OmsClient\V2\Dto;
 
 final class GetICBufferStatusResponse
 {
-    public const BUFFER_STATUS_PENDING = 'pending';
-    public const BUFFER_STATUS_ACTIVE = 'active';
-    public const BUFFER_STATUS_EXHAUSTED = 'exhausted';
-    public const BUFFER_STATUS_REJECTED = 'rejected';
-    public const BUFFER_STATUS_CLOSED = 'closed';
+    public const BUFFER_STATUS_PENDING = 'PENDING';
+    public const BUFFER_STATUS_ACTIVE = 'ACTIVE';
+    public const BUFFER_STATUS_EXHAUSTED = 'EXHAUSTED';
+    public const BUFFER_STATUS_REJECTED = 'REJECTED';
+    public const BUFFER_STATUS_CLOSED = 'CLOSED';
 
     /**
      * @var string
@@ -39,7 +39,7 @@ final class GetICBufferStatusResponse
     /**
      * @var PoolInfo[]
      */
-    private $poolInfos;
+    private $poolInfos = [];
     /**
      * @var string
      */
@@ -58,7 +58,6 @@ final class GetICBufferStatusResponse
      * @param int $totalCodes
      * @param int $unavailableCodes
      * @param int $leftInBuffer
-     * @param PoolInfo[] $poolInfos
      * @param string $bufferStatus
      */
     public function __construct(
@@ -68,7 +67,6 @@ final class GetICBufferStatusResponse
         int $totalCodes,
         int $unavailableCodes,
         int $leftInBuffer,
-        array $poolInfos,
         string $bufferStatus
     ) {
         $this->omsId = $omsId;
@@ -77,7 +75,6 @@ final class GetICBufferStatusResponse
         $this->totalCodes = $totalCodes;
         $this->unavailableCodes = $unavailableCodes;
         $this->leftInBuffer = $leftInBuffer;
-        $this->poolInfos = $poolInfos;
         $this->bufferStatus = $bufferStatus;
     }
 
@@ -117,6 +114,14 @@ final class GetICBufferStatusResponse
     public function getPoolInfos(): array
     {
         return $this->poolInfos;
+    }
+
+    /**
+     * @param PoolInfo[] $poolInfos
+     */
+    public function setPoolInfos(array $poolInfos): void
+    {
+        $this->poolInfos = $poolInfos;
     }
 
     public function getBufferStatus(): string

--- a/src/V2/OmsApi.php
+++ b/src/V2/OmsApi.php
@@ -169,10 +169,8 @@ final class OmsApi
             return $headers;
         }
 
-        $base64encoded = base64_encode($data);
-
         try {
-            $headers['X-Signature'] = $signer->sign($base64encoded);
+            $headers['X-Signature'] = $signer->sign($data);
         } catch (\Throwable $exception) {
             throw OmsSignerErrorException::becauseOfError($exception);
         }

--- a/tests/V2/OmsApiTest.php
+++ b/tests/V2/OmsApiTest.php
@@ -102,7 +102,7 @@ final class OmsApiTest extends TestCase
                     ->withBody(stream_for(self::API_RESPONSE))
             );
 
-        $expectedResult = new GetICBufferStatusResponse('', '', '', 0, 0, 0, [], '');
+        $expectedResult = new GetICBufferStatusResponse('', '', '', 0, 0, 0, '');
         $this->serializer->expects($this->once())
             ->method('deserialize')
             ->willReturn($expectedResult);
@@ -240,7 +240,7 @@ final class OmsApiTest extends TestCase
 
         $signer = $this->createMock(SignerInterface::class);
         $signer->method('sign')
-            ->with(base64_encode($serializedRequest))
+            ->with($serializedRequest)
             ->willReturn($signature);
 
         $result = $this->api->createOrderForEmissionIC(
@@ -319,7 +319,7 @@ final class OmsApiTest extends TestCase
                     ->withBody(stream_for(self::API_RESPONSE))
             );
 
-        $expectedResult = new GetICBufferStatusResponse('', '', '', 0, 0, 0, [], '');
+        $expectedResult = new GetICBufferStatusResponse('', '', '', 0, 0, 0, '');
         $this->serializer->expects($this->once())
             ->method('deserialize')
             ->with(


### PR DESCRIPTION
Fixed:
- wrong field name in CRPT response
- wrong signing procedure